### PR TITLE
Chore: Update workflow to v2

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -12,12 +12,11 @@ on:
 
 jobs:
   call-workflow:
-    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@main
+    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v2
     with:
       app-name: subwayside-ui
       environment: ${{ github.event.inputs.environment || 'staging' }}
     secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
#### Summary of changes
This PR updates the deploy workflow to use v2 of the `deploy-ecs` workflow. This updated workflow assumes an IAM role instead of relying on long-lasting AWS keys for an IAM user

Successful deploy [here](https://github.com/mbta/subwayside_ui/actions/runs/6633714923)